### PR TITLE
feat: centralized remote sync logic 

### DIFF
--- a/src/autosync.rs
+++ b/src/autosync.rs
@@ -1,3 +1,4 @@
+use crate::cli::Command;
 use crate::commands::{CheckUpdateCmd, FetchCmd, SelfUpdateCmd};
 use crate::config::loader::{get_config_path, load_config_detached};
 use crate::config::remote::RemoteConfig;
@@ -6,11 +7,13 @@ use crate::util::logging::{LogLevel, print_log};
 /// Perform remote config auto-sync if enabled in [remote] and internet is available.
 /// This should be called early in main().
 pub async fn try_auto_sync(command: &crate::cli::Command) {
-    if matches!(command, crate::cli::Command::Fetch(FetchCmd))
-        || matches!(command, crate::cli::Command::SelfUpdate(SelfUpdateCmd))
-        || matches!(command, crate::cli::Command::CheckUpdate(CheckUpdateCmd))
-    {
-        return;
+    match command {
+        Command::Fetch(FetchCmd)
+        | Command::SelfUpdate(SelfUpdateCmd)
+        | Command::CheckUpdate(CheckUpdateCmd) => {
+            return;
+        }
+        _ => {}
     }
 
     let cfg_path = get_config_path().await;

--- a/src/commands/apply.rs
+++ b/src/commands/apply.rs
@@ -72,7 +72,7 @@ impl Runnable for ApplyCmd {
 
             let remote = RemoteConfig {
                 url: url.clone(),
-                autosync: true,
+                autosync: false,
             };
             remote.fetch().await?;
             remote.save().await?;

--- a/src/commands/apply.rs
+++ b/src/commands/apply.rs
@@ -70,20 +70,12 @@ impl Runnable for ApplyCmd {
                 bail!("Aborted apply: --url is passed despite local config.")
             }
 
-            let remote_txt = RemoteConfig {
+            let remote = RemoteConfig {
                 url: url.clone(),
                 autosync: true,
-            }
-            .fetch()
-            .await?
-            .as_table()
-            .unwrap()
-            .to_string();
-
-            if let Some(parent) = config_path.parent() {
-                fs::create_dir_all(parent).await?;
-            }
-            fs::write(&config_path, remote_txt).await?;
+            };
+            remote.fetch().await?;
+            remote.save().await?;
 
             print_log(
                 LogLevel::Info,

--- a/src/config/remote.rs
+++ b/src/config/remote.rs
@@ -1,8 +1,34 @@
 use anyhow::{Context, Result, bail};
 use reqwest::Client;
+use tokio::fs;
+use tokio::io::AsyncWriteExt;
+use tokio::sync::OnceCell;
 use toml::Value;
 
-use crate::util::logging::{LogLevel, print_log};
+use crate::{
+    config::loader::{get_config_path, load_config},
+    util::logging::{LogLevel, print_log},
+};
+
+/// Global OnceCell holding the fetched remote config.
+/// This is accessible from outside the struct.
+pub static REMOTE_CONFIG: OnceCell<Value> = OnceCell::const_new();
+
+/// Merge remote config into local config, preserving [remote] if not present in remote.
+fn merge_remote_config(local: &toml::Value, remote: &toml::Value) -> toml::Value {
+    let empty_map = toml::map::Map::new();
+    let remote_table = remote.as_table().unwrap_or(&empty_map);
+    let local_table = local.as_table().unwrap_or(&empty_map);
+
+    let mut merged_table = remote_table.clone();
+
+    if !remote_table.contains_key("remote") {
+        if let Some(local_remote) = local_table.get("remote") {
+            merged_table.insert("remote".to_string(), local_remote.clone());
+        }
+    }
+    toml::Value::Table(merged_table)
+}
 
 /// Represents the [remote] config section.
 #[derive(Debug, Clone)]
@@ -24,47 +50,78 @@ impl RemoteConfig {
         Some(Self { url, autosync })
     }
 
-    /// Fetch the remote config file as TOML.
-    pub async fn fetch(&self) -> Result<Value> {
+    /// Fetch the remote config file as TOML, only once per process lifetime.
+    pub async fn fetch(&self) -> Result<()> {
+        REMOTE_CONFIG
+            .get_or_try_init(|| async {
+                print_log(
+                    LogLevel::Info,
+                    &format!("Fetching remote config from {}", self.url),
+                );
+
+                let client = Client::builder()
+                    .user_agent("cutler-remote-config")
+                    .build()?;
+                let resp =
+                    client.get(&self.url).send().await.with_context(|| {
+                        format!("Failed to fetch remote config from {}", self.url)
+                    })?;
+
+                if !resp.status().is_success() {
+                    bail!("Failed to fetch remote config: HTTP {}", resp.status());
+                }
+
+                let text = resp.text().await?;
+                let parsed = text
+                    .parse::<Value>()
+                    .with_context(|| format!("Invalid TOML config fetched from {}", self.url))?;
+
+                Ok(parsed)
+            })
+            .await?;
+        Ok(())
+    }
+
+    /// Save the fetched remote config to the given path.
+    pub async fn save(&self) -> Result<()> {
+        let path = get_config_path().await;
+        let config = REMOTE_CONFIG
+            .get()
+            .ok_or_else(|| anyhow::anyhow!("Remote config not fetched yet"))?;
+
+        let toml_string =
+            toml::to_string(config).with_context(|| "Failed to serialize remote config to TOML")?;
+
+        let mut file = fs::File::create(path).await?;
+        file.write_all(toml_string.as_bytes()).await?;
+
         print_log(
             LogLevel::Info,
-            &format!("Fetching remote config from {}", self.url),
+            "Successfully saved remote config to destination.",
         );
-
-        let client = Client::builder()
-            .user_agent("cutler-remote-config")
-            .build()?;
-        let resp = client
-            .get(&self.url)
-            .send()
-            .await
-            .with_context(|| format!("Failed to fetch remote config from {}", self.url))?;
-
-        if !resp.status().is_success() {
-            bail!("Failed to fetch remote config: HTTP {}", resp.status());
-        }
-
-        let text = resp.text().await?;
-        let parsed = text
-            .parse::<Value>()
-            .with_context(|| format!("Invalid TOML config fetched from {}", self.url))?;
-
-        Ok(parsed)
+        Ok(())
     }
-}
 
-/// Merge remote config into local config, preserving [remote] if not present in remote.
-pub fn merge_remote_config(local: &toml::Value, remote: &toml::Value) -> toml::Value {
-    let empty_map = toml::map::Map::new();
-    let remote_table = remote.as_table().unwrap_or(&empty_map);
-    let local_table = local.as_table().unwrap_or(&empty_map);
+    /// Merge the fetched remote config into the local config, preserving [remote] if not present in remote,
+    /// and save the merged config to disk.
+    pub async fn save_merge_local(&self) -> Result<()> {
+        let local = load_config(false).await?;
+        let remote = REMOTE_CONFIG
+            .get()
+            .ok_or_else(|| anyhow::anyhow!("Remote config not fetched yet"))?;
+        let merged = merge_remote_config(&local, remote);
 
-    let mut merged_table = remote_table.clone();
+        let path = get_config_path().await;
+        let toml_string = toml::to_string(&merged)
+            .with_context(|| "Failed to serialize merged config to TOML")?;
 
-    if !remote_table.contains_key("remote") {
-        if let Some(local_remote) = local_table.get("remote") {
-            merged_table.insert("remote".to_string(), local_remote.clone());
-        }
+        let mut file = fs::File::create(path).await?;
+        file.write_all(toml_string.as_bytes()).await?;
+
+        print_log(
+            LogLevel::Info,
+            "Successfully saved merged config to destination.",
+        );
+        Ok(())
     }
-    toml::Value::Table(merged_table)
 }


### PR DESCRIPTION
- Now, the remote sync logic is completely centralized under `src/config/remote.rs` and does not require additional code to be scattered in other parts of the codebase to *unreliably* sync the configuration.