### PR TITLE
feat: execution modes for `apply` and `exec` commands

### DIFF
--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -2,6 +2,7 @@
 
 use crate::commands::Runnable;
 
+use crate::exec::runner::ExecMode;
 use crate::{config::loader::load_config, exec::runner};
 use anyhow::Result;
 use async_trait::async_trait;
@@ -12,6 +13,14 @@ pub struct ExecCmd {
     /// The command to execute. Defaults to 'all' if not passed.
     #[arg(value_name = "NAME")]
     pub name: Option<String>,
+
+    /// Execute all commands.
+    #[arg(short, long, conflicts_with = "flagged")]
+    pub all: bool,
+
+    /// Execute flagged commands only.
+    #[arg(short, long, conflicts_with = "all")]
+    pub flagged: bool,
 }
 
 #[async_trait]
@@ -20,10 +29,18 @@ impl Runnable for ExecCmd {
         // load & parse config
         let toml = load_config(true).await?;
 
+        let mode = if self.all {
+            ExecMode::All
+        } else if self.flagged {
+            ExecMode::Flagged
+        } else {
+            ExecMode::Regular
+        };
+
         if let Some(cmd_name) = &self.name {
             runner::run_one(&toml, cmd_name).await?;
         } else {
-            runner::run_all(&toml).await?;
+            runner::run_all(&toml, mode).await?;
         }
 
         Ok(())

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -7,11 +7,8 @@ use crate::{
     },
     commands::Runnable,
     config::loader::load_config,
-    domains::{collect, effective, read_current},
-    util::{
-        convert::normalize,
-        logging::{BOLD, GREEN, LogLevel, RED, RESET, print_log},
-    },
+    domains::{collect, convert::normalize, effective, read_current},
+    util::logging::{BOLD, GREEN, LogLevel, RED, RESET, print_log},
 };
 use anyhow::Result;
 use async_trait::async_trait;

--- a/src/commands/unapply.rs
+++ b/src/commands/unapply.rs
@@ -10,9 +10,9 @@ use tokio::fs;
 use crate::{
     cli::atomic::should_dry_run,
     commands::Runnable,
+    domains::convert::{string_to_toml_value, toml_to_prefvalue},
     snapshot::state::{Snapshot, get_snapshot_path},
     util::{
-        convert::{string_to_toml_value, toml_to_prefvalue},
         io::{notify, restart_services},
         logging::{LogLevel, print_log},
     },

--- a/src/domains/convert.rs
+++ b/src/domains/convert.rs
@@ -60,6 +60,32 @@ pub fn string_to_toml_value(s: &str) -> toml::Value {
     }
 }
 
+/// Turns a PrefValue object to a string.
+pub fn prefvalue_to_string(val: &PrefValue) -> String {
+    match val {
+        PrefValue::Boolean(b) => b.to_string(),
+        PrefValue::Integer(i) => i.to_string(),
+        PrefValue::Float(f) => f.to_string(),
+        PrefValue::String(s) => s.clone(),
+        PrefValue::Array(arr) => {
+            let inner = arr
+                .iter()
+                .map(prefvalue_to_string)
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("[{inner}]")
+        }
+        PrefValue::Dictionary(dict) => {
+            let inner = dict
+                .iter()
+                .map(|(k, v)| format!("{}: {}", k, prefvalue_to_string(v)))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("{{{inner}}}")
+        }
+    }
+}
+
 /// Normalize a toml::Value to a string.
 pub fn normalize(value: &Value) -> String {
     match value {

--- a/src/domains/mod.rs
+++ b/src/domains/mod.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod collector;
+pub mod convert;
 pub use collector::{collect, effective, read_current};

--- a/src/snapshot/state.rs
+++ b/src/snapshot/state.rs
@@ -21,6 +21,7 @@ pub struct ExternalCommandState {
     pub run: String,
     pub sudo: bool,
     pub ensure_first: bool,
+    pub flag: bool,
     pub required: Vec<String>,
 }
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-pub mod convert;
 pub mod io;
 pub mod logging;
 pub mod sudo;

--- a/tests/external_test.rs
+++ b/tests/external_test.rs
@@ -4,7 +4,7 @@
 mod tests {
     use cutler::{
         cli::atomic::set_dry_run,
-        exec::runner::{run_all, run_one},
+        exec::runner::{ExecMode, run_all, run_one},
     };
     use toml::{Value, value::Table};
 
@@ -28,7 +28,7 @@ mod tests {
         root.insert("vars".into(), Value::Table(vars));
         root.insert("commands".into(), Value::Table(commands));
 
-        assert!(run_all(&root).await.is_ok());
+        assert!(run_all(&root, ExecMode::Regular).await.is_ok());
     }
 
     #[tokio::test]

--- a/tests/snapshot_test.rs
+++ b/tests/snapshot_test.rs
@@ -55,6 +55,7 @@ mod tests {
             run: "echo Hello World".to_string(),
             sudo: false,
             ensure_first: false,
+            flag: false,
             required: vec!["echo".to_string()],
         };
         assert_eq!(command.run, "echo Hello World");
@@ -94,6 +95,7 @@ mod tests {
             run: "echo Hello".to_string(),
             sudo: false,
             ensure_first: false,
+            flag: false,
             required: vec!["echo".to_string()],
         });
 
@@ -102,6 +104,7 @@ mod tests {
             run: "hostname -s macbook".to_string(),
             sudo: true,
             ensure_first: false,
+            flag: false,
             required: vec!["hostname".to_string()],
         });
 


### PR DESCRIPTION
This PR adds a new `ExecMode` enum for the external command runner, which can decide between three modes:

1. `All` (runs all commands)
2. `Flagged` (runs only the commands which have `flag = true` as a TOML field), and
3. `Regular` (runs every command exxcept those which have `flag = true`)

I also generally work on improving the project's structure with each PR so that'll be a thing too for this PR as well.
