### PR TITLE
chore: `Snapshot` struct and `get_snapshot_path()` improvements

### DIFF
--- a/src/commands/apply.rs
+++ b/src/commands/apply.rs
@@ -22,7 +22,6 @@ use anyhow::{Result, bail};
 use async_trait::async_trait;
 use clap::Args;
 use defaults_rs::{Domain, preferences::Preferences};
-use tokio::fs;
 use toml::Value;
 
 #[derive(Args, Debug)]
@@ -98,8 +97,8 @@ impl Runnable for ApplyCmd {
         let domains = collector::collect(&config)?;
 
         // load the old snapshot (if any), otherwise create a new instance
-        let snap_path = get_snapshot_path();
-        let snap = if fs::try_exists(&snap_path).await? {
+        let snap_path = get_snapshot_path()?;
+        let snap = if Snapshot::is_loadable().await {
             Snapshot::load(&snap_path).await.unwrap_or_else(|e| {
                 print_log(
                     LogLevel::Warning,

--- a/src/commands/config/delete.rs
+++ b/src/commands/config/delete.rs
@@ -31,14 +31,14 @@ impl Runnable for ConfigDeleteCmd {
 
         // offer user to unapply settings if any had been previously applied
         // (use snapshot to detect)
-        let snapshot_path = get_snapshot_path();
-        if fs::try_exists(&snapshot_path).await? {
+        let snap_path = get_snapshot_path()?;
+        if Snapshot::is_loadable().await {
             print_log(
                 LogLevel::Info,
                 &format!(
                     "Found a snapshot at {:?}. It contains {} settings.",
-                    snapshot_path,
-                    Snapshot::load(&snapshot_path).await?.settings.len()
+                    snap_path,
+                    Snapshot::load(&snap_path).await?.settings.len()
                 ),
             );
             if confirm("Unapply all previously applied defaults?") {
@@ -51,8 +51,8 @@ impl Runnable for ConfigDeleteCmd {
 
         if dry_run {
             print_log(LogLevel::Dry, &format!("Would delete {config_path:?}"));
-            if fs::try_exists(&snapshot_path).await? {
-                print_log(LogLevel::Dry, &format!("Would delete {snapshot_path:?}"));
+            if fs::try_exists(&snap_path).await? {
+                print_log(LogLevel::Dry, &format!("Would delete {snap_path:?}"));
             }
         } else {
             fs::remove_file(&config_path).await?;
@@ -60,11 +60,11 @@ impl Runnable for ConfigDeleteCmd {
                 LogLevel::Fruitful,
                 &format!("Deleted config at {config_path:?}"),
             );
-            if fs::try_exists(&snapshot_path).await? {
-                fs::remove_file(&snapshot_path).await?;
+            if fs::try_exists(&snap_path).await? {
+                fs::remove_file(&snap_path).await?;
                 print_log(
                     LogLevel::Info,
-                    &format!("Deleted snapshot at {snapshot_path:?}"),
+                    &format!("Deleted snapshot at {snap_path:?}"),
                 );
             }
         }

--- a/src/commands/reset.rs
+++ b/src/commands/reset.rs
@@ -11,7 +11,7 @@ use crate::{
     commands::Runnable,
     config::loader::Config,
     domains::{collect, effective, read_current},
-    snapshot::{Snapshot, state::get_snapshot_path},
+    snapshot::{Snapshot, get_snapshot_path},
     util::{
         io::{confirm, notify, restart_services},
         logging::{LogLevel, print_log},

--- a/src/commands/reset.rs
+++ b/src/commands/reset.rs
@@ -11,7 +11,7 @@ use crate::{
     commands::Runnable,
     config::loader::Config,
     domains::{collect, effective, read_current},
-    snapshot::state::get_snapshot_path,
+    snapshot::{Snapshot, state::get_snapshot_path},
     util::{
         io::{confirm, notify, restart_services},
         logging::{LogLevel, print_log},
@@ -87,8 +87,8 @@ impl Runnable for ResetCmd {
         }
 
         // remove snapshot if present
-        let snap_path = get_snapshot_path();
-        if fs::try_exists(&snap_path).await? {
+        let snap_path = get_snapshot_path()?;
+        if Snapshot::is_loadable().await {
             if dry_run {
                 print_log(
                     LogLevel::Dry,

--- a/src/commands/unapply.rs
+++ b/src/commands/unapply.rs
@@ -10,7 +10,7 @@ use crate::{
     cli::atomic::should_dry_run,
     commands::Runnable,
     domains::convert::{string_to_toml_value, toml_to_prefvalue},
-    snapshot::state::{Snapshot, get_snapshot_path},
+    snapshot::{get_snapshot_path, state::Snapshot},
     util::{
         io::{notify, restart_services},
         logging::{LogLevel, print_log},

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod state;
-pub use state::{Snapshot, get_snapshot_path};
+pub use state::Snapshot;
+pub mod path;
+pub use path::get_snapshot_path;

--- a/src/snapshot/path.rs
+++ b/src/snapshot/path.rs
@@ -1,0 +1,18 @@
+use anyhow::{Context, Result};
+use std::{path::PathBuf, sync::OnceLock};
+
+/// The static snapshot path to use throughout each command run.
+/// This is to make sure that accidental variable changes don't alter the snapshot being written.
+static SNAP_PATH: OnceLock<PathBuf> = OnceLock::new();
+
+/// Where on disk the snapshot lives (`~/.cutler_snapshot`).
+pub fn get_snapshot_path() -> Result<PathBuf> {
+    if let Some(cached) = SNAP_PATH.get().cloned() {
+        return Ok(cached);
+    }
+
+    let home = dirs::home_dir().context("Could not determine home directory")?;
+    let path = home.join(".cutler_snapshot");
+    SNAP_PATH.set(path.clone()).ok();
+    Ok(path)
+}

--- a/src/snapshot/state.rs
+++ b/src/snapshot/state.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::{env, path::PathBuf, sync::OnceLock};
 use tokio::fs;
@@ -24,28 +24,47 @@ pub struct Snapshot {
 }
 
 impl Snapshot {
+    pub async fn is_loadable() -> bool {
+        fs::try_exists(get_snapshot_path().unwrap_or_default())
+            .await
+            .unwrap_or_default()
+    }
+
     pub fn new() -> Self {
         Snapshot {
             settings: Vec::new(),
             version: env!("CARGO_PKG_VERSION").into(),
-            snapshot_path: get_snapshot_path(),
+            snapshot_path: get_snapshot_path().expect("Failed to get snapshot path"),
             exec_run_count: 0,
         }
     }
 
     pub async fn save(&self) -> Result<()> {
         if let Some(dir) = self.snapshot_path.parent() {
-            fs::create_dir_all(dir).await?;
+            fs::create_dir_all(dir)
+                .await
+                .context("Failed to create snapshot directory")?;
         }
-        let json = serde_json::to_string(self)?;
-        fs::write(&self.snapshot_path, json).await?;
+        let json = serde_json::to_string(self).context("Failed to serialize Snapshot to JSON")?;
+        fs::write(&self.snapshot_path, json)
+            .await
+            .with_context(|| format!("Failed to write snapshot to {:?}", &self.snapshot_path))?;
         Ok(())
     }
 
     pub async fn load(path: &PathBuf) -> Result<Self> {
-        let txt = fs::read_to_string(path).await?;
-        let snap: Snapshot = serde_json::from_str(&txt)?;
+        let txt = fs::read_to_string(path)
+            .await
+            .with_context(|| format!("Failed to read snapshot file {:?}", path))?;
+        let snap: Snapshot =
+            serde_json::from_str(&txt).context("Failed to deserialize Snapshot from JSON")?;
         Ok(snap)
+    }
+
+    pub async fn delete(&self) -> Result<()> {
+        fs::remove_file(&self.snapshot_path)
+            .await
+            .with_context(|| format!("Could not delete snapshot file {:?}.", &self.snapshot_path))
     }
 }
 
@@ -54,19 +73,13 @@ impl Snapshot {
 static SNAP_PATH: OnceLock<PathBuf> = OnceLock::new();
 
 /// Where on disk the snapshot lives (`~/.cutler_snapshot`).
-pub fn get_snapshot_path() -> PathBuf {
-    if let Some(path) = SNAP_PATH.get().cloned() {
-        return path;
+pub fn get_snapshot_path() -> Result<PathBuf> {
+    if let Some(cached) = SNAP_PATH.get().cloned() {
+        return Ok(cached);
     }
 
-    let path: PathBuf;
-
-    if let Some(home) = dirs::home_dir() {
-        path = home.join(".cutler_snapshot");
-    } else {
-        path = PathBuf::from(".cutler_snapshot");
-    }
-
+    let home = dirs::home_dir().context("Could not determine home directory")?;
+    let path = home.join(".cutler_snapshot");
     SNAP_PATH.set(path.clone()).ok();
-    path
+    Ok(path)
 }

--- a/src/snapshot/state.rs
+++ b/src/snapshot/state.rs
@@ -2,8 +2,10 @@
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
-use std::{env, path::PathBuf, sync::OnceLock};
+use std::{env, path::PathBuf};
 use tokio::fs;
+
+use crate::snapshot::get_snapshot_path;
 
 /// A single defaults‑setting change.
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -20,7 +22,7 @@ pub struct Snapshot {
     pub exec_run_count: i32,
     pub version: String,
     #[serde(skip)]
-    pub snapshot_path: PathBuf,
+    pub path: PathBuf,
 }
 
 impl Snapshot {
@@ -34,21 +36,21 @@ impl Snapshot {
         Snapshot {
             settings: Vec::new(),
             version: env!("CARGO_PKG_VERSION").into(),
-            snapshot_path: get_snapshot_path().expect("Failed to get snapshot path"),
+            path: get_snapshot_path().expect("Failed to get snapshot path"),
             exec_run_count: 0,
         }
     }
 
     pub async fn save(&self) -> Result<()> {
-        if let Some(dir) = self.snapshot_path.parent() {
+        if let Some(dir) = self.path.parent() {
             fs::create_dir_all(dir)
                 .await
                 .context("Failed to create snapshot directory")?;
         }
         let json = serde_json::to_string(self).context("Failed to serialize Snapshot to JSON")?;
-        fs::write(&self.snapshot_path, json)
+        fs::write(&self.path, json)
             .await
-            .with_context(|| format!("Failed to write snapshot to {:?}", &self.snapshot_path))?;
+            .with_context(|| format!("Failed to write snapshot to {:?}", &self.path))?;
         Ok(())
     }
 
@@ -62,24 +64,8 @@ impl Snapshot {
     }
 
     pub async fn delete(&self) -> Result<()> {
-        fs::remove_file(&self.snapshot_path)
+        fs::remove_file(&self.path)
             .await
-            .with_context(|| format!("Could not delete snapshot file {:?}.", &self.snapshot_path))
+            .with_context(|| format!("Could not delete snapshot file {:?}.", &self.path))
     }
-}
-
-/// The static snapshot path to use throughout each command run.
-/// This is to make sure that accidental variable changes don't alter the snapshot being written.
-static SNAP_PATH: OnceLock<PathBuf> = OnceLock::new();
-
-/// Where on disk the snapshot lives (`~/.cutler_snapshot`).
-pub fn get_snapshot_path() -> Result<PathBuf> {
-    if let Some(cached) = SNAP_PATH.get().cloned() {
-        return Ok(cached);
-    }
-
-    let home = dirs::home_dir().context("Could not determine home directory")?;
-    let path = home.join(".cutler_snapshot");
-    SNAP_PATH.set(path.clone()).ok();
-    Ok(path)
 }

--- a/tests/snapshot_test.rs
+++ b/tests/snapshot_test.rs
@@ -13,7 +13,7 @@ mod tests {
     #[test]
     fn test_get_snapshot_path() {
         // Test that get_snapshot_path returns .cutler_snapshot in the home directory
-        let snapshot_path = get_snapshot_path();
+        let snapshot_path = get_snapshot_path().unwrap();
         assert_eq!(
             snapshot_path,
             dirs::home_dir().unwrap().join(".cutler_snapshot")

--- a/tests/snapshot_test.rs
+++ b/tests/snapshot_test.rs
@@ -4,7 +4,10 @@
 mod tests {
     use cutler::{
         exec::runner::ExecJob,
-        snapshot::state::{SettingState, Snapshot, get_snapshot_path},
+        snapshot::{
+            get_snapshot_path,
+            state::{SettingState, Snapshot},
+        },
     };
     use std::{collections::HashMap, env, path::PathBuf};
     use tempfile::TempDir;
@@ -80,7 +83,7 @@ mod tests {
         let snapshot_path = temp_dir.path().join("test_snapshot.json");
 
         // Save the snapshot
-        snapshot.snapshot_path = snapshot_path.clone();
+        snapshot.path = snapshot_path.clone();
         snapshot.save().await.unwrap();
 
         // Verify file exists and has content


### PR DESCRIPTION
This PR modifies the `Snapshot` struct as well as the `get_snapshot_path()` function to achieve the following:

- The removal of backup paths for snapshots. If the base path of $HOME/.cutler_snapshot cannot be loaded, the function now returns a `Result` for other functions to consume.
- The struct now has two new methods: `is_loadable()` and `delete()`. These are both meant to replace barebones `fs` calls throughout the codebase, specifically for snapshots.

I might also work on a similar modification with the `Config` struct.
